### PR TITLE
Use long with scanf()'s %ld format specifier

### DIFF
--- a/HDRloader.cpp
+++ b/HDRloader.cpp
@@ -64,7 +64,7 @@ bool HDRLoader::load(const char *fileName, HDRImage &res)
 			break;
 	}
 
-	int w, h;
+	long w, h;
 	if (!sscanf(reso, "-Y %ld +X %ld", &h, &w)) {
 		fclose(file);
 		return false;


### PR DESCRIPTION
I changed the local variables to parse the image resolution into to `long`. `int` and `long` are both 32-bit under Win32, but `long` is 64-bit under LP64. On my Linux machine this resulted in getting height 0 when loading the Topanga Forest HDR map. Since `int` and `long` are basically the same, I would also expect this to work as intended under Windows..
