### PR TITLE
Fixed fetching BVH from texture instead of global memory

### DIFF
--- a/CudaBVH.cpp
+++ b/CudaBVH.cpp
@@ -266,12 +266,10 @@ void CudaBVH::woopifyTri(const BVH& bvh, int triIdx)
 
 	// fetch the 3 vertex indices of this triangle
 	const Vec3i& vtxInds = bvh.getScene()->getTriangle(bvh.getTriIndices()[triIdx]).vertices; 
-	const Vec3f& v0 = Vec3f(vertices[vtxInds._v[0]].x, vertices[vtxInds._v[0]].y, vertices[vtxInds._v[0]].z); // vtx xyz pos voor eerste triangle vtx
-	//const Vec3f& v1 = bvh.getScene()->getVertex(vtxInds.y);
-	const Vec3f& v1 = Vec3f(vertices[vtxInds._v[1]].x, vertices[vtxInds._v[1]].y, vertices[vtxInds._v[1]].z); // vtx xyz pos voor tweede triangle vtx
-	//const Vec3f& v2 = bvh.getScene()->getVertex(vtxInds.z);
-	const Vec3f& v2 = Vec3f(vertices[vtxInds._v[2]].x, vertices[vtxInds._v[2]].y, vertices[vtxInds._v[2]].z); // vtx xyz pos voor derde triangle vtx
-
+  const Vec3f& v0 = bvh.getScene()->getVertex(vtxInds.x);
+  const Vec3f& v1 = bvh.getScene()->getVertex(vtxInds.y);
+	const Vec3f& v2 = bvh.getScene()->getVertex(vtxInds.z);
+	
 	// regular triangles (for debugging only)
 	m_debugtri[0] = Vec4f(v0.x, v0.y, v0.z, 0.0f);
 	m_debugtri[1] = Vec4f(v1.x, v1.y, v1.z, 0.0f);

--- a/Geometry.h
+++ b/Geometry.h
@@ -20,7 +20,5 @@ struct Triangle {
 	unsigned _idx1;
 	unsigned _idx2;
 	unsigned _idx3;
-
-	Vec3f _center;
 };
 

--- a/Scene.h
+++ b/Scene.h
@@ -36,12 +36,9 @@ public:
 	struct Triangle
 	{
 		Vec3i       vertices;   //3 vertex indices of triangle
-		Vec3f       normal;
-		Triangle() : vertices(Vec3i(0, 0, 0)), normal(Vec3f(0, 0, 0)) {}
+    Triangle() : vertices(Vec3i(0, 0, 0)) {};
 	};
 
-
-#if !FW_CUDA
 public:
 		
 	Scene(const S32 numTris, const S32 numVerts, const Array<Triangle>& tris, const Array<Vec3f>& verts) : 
@@ -66,7 +63,5 @@ private:
 	S32             m_numVerts;
 	Array<Triangle>      m_tris;     
 	Array<Vec3f>         m_verts; 
-
-#endif
 };
 

--- a/SceneLoader.cpp
+++ b/SceneLoader.cpp
@@ -154,10 +154,6 @@ void load_object(const char *filename)
 							Vertex *vertexA = &vertices[idx1];
 							Vertex *vertexB = &vertices[idx2];
 							Vertex *vertexC = &vertices[idx3];
-							pCurrentTriangle->_center = Vec3f(
-								(vertexA->x + vertexB->x + vertexC->x) / 3.0f,
-								(vertexA->y + vertexB->y + vertexC->y) / 3.0f,
-								(vertexA->z + vertexB->z + vertexC->z) / 3.0f);
 							pCurrentTriangle++;
 						}
 					}
@@ -573,12 +569,6 @@ void load_object(const char *filename)
 				Vertex *vertexB = &vertices[currentfaceinds.y - 1];
 				Vertex *vertexC = &vertices[currentfaceinds.z - 1];
 
-
-				pCurrentTriangle->_center = Vec3f(
-					(vertexA->x + vertexB->x + vertexC->x) / 3.0f,
-					(vertexA->y + vertexB->y + vertexC->y) / 3.0f,
-					(vertexA->z + vertexB->z + vertexC->z) / 3.0f);
-
 				pCurrentTriangle++;
 			}
 		}
@@ -645,7 +635,7 @@ float processgeo(){
 		vertices[i] -= origCenter;
 		//vertices[i].y += origCenter.y;
 		//vertices[i] *= (MaxCoordAfterRescale / maxi);
-		vertices[i] *= 20; // 0.25
+		vertices[i] *= 0.1; // 0.25
 	}
 
 	return MaxCoordAfterRescale;

--- a/linear_math.h
+++ b/linear_math.h
@@ -269,19 +269,6 @@ inline int popc32(U32 mask)
 	return result;
 }
 
-typedef unsigned long U64;
-
-inline int popc64(U64 mask)
-{
-	U32 lo = (U32)mask;
-	U32 hi = (U32)(mask >> 32);
-	int result = c_popc8LUT[lo & 0xffu] + c_popc8LUT[hi & 0xffu];
-	result += c_popc8LUT[(lo >> 8) & 0xffu] + c_popc8LUT[(hi >> 8) & 0xffu];
-	result += c_popc8LUT[(lo >> 16) & 0xffu] + c_popc8LUT[(hi >> 16) & 0xffu];
-	result += c_popc8LUT[lo >> 24] + c_popc8LUT[hi >> 24];
-	return result;
-}
-
 //------------------------------------------------------------------------
 
 Vec4f Mat4f::getRow(int idx) const

--- a/main.cpp
+++ b/main.cpp
@@ -74,7 +74,7 @@ int triangle_count = 0;
 int triWoopSize = 0;
 int triDebugSize = 0;
 int triIndicesSize = 0;
-float scalefactor = 1.2f;
+float scalefactor = .2f;
 __device__ float timer = 0.0f;
 bool nocachedBVH = false;
 
@@ -128,8 +128,9 @@ void disp(void)
 	
 	cudaThreadSynchronize();
 	cudaGLUnmapBufferObject(vbo);
-	//glFlush();
-	glBindBuffer(GL_ARRAY_BUFFER, vbo);
+	glFlush();
+  glFinish();
+  glBindBuffer(GL_ARRAY_BUFFER, vbo);
 	glVertexPointer(2, GL_FLOAT, 12, 0);
 	glColorPointer(4, GL_UNSIGNED_BYTE, 12, (GLvoid*)8);
 
@@ -285,10 +286,8 @@ void createBVH(){
 
 	std::cout << "Building CudaBVH\n";
 	// create CUDA friendly BVH datastructure
-	gpuBVH = new CudaBVH(myBVH, BVHLayout_Compact);  // Fermi BVH layout = compact. BVH layout for Kepler kernel Compact2
+	gpuBVH = new CudaBVH(myBVH, BVHLayout_Compact2);  // BVH layout for Kepler kernel Compact2
 	std::cout << "CudaBVH successfully created\n";
-
-	std::cout << "Hi Sam!  How you doin'?" << std::endl;
 
 	cpuNodePtr = gpuBVH->getGpuNodes();
 	cpuTriWoopPtr = gpuBVH->getGpuTriWoop();
@@ -367,6 +366,9 @@ int main(int argc, char** argv){
 	glutInitWindowPosition(100, 100); // specify the initial window position
 	glutInitWindowSize(scrwidth, scrheight); // specify the initial window size
 	glutCreateWindow("MatchingSocks, CUDA path tracer using SplitBVH"); // create the window and set title
+
+  cudaGLSetGLDevice(0);
+  cudaSetDevice(0);
 
 	// initialise OpenGL:
 	glClearColor(0.0, 0.0, 0.0, 0.0);


### PR DESCRIPTION
I "fixed" your code to fetch the BVH nodes using tex1Dfetch. The trick is to use Compact2 for Kepler, so that the nodeAddresses are devided by 16 and the offsets can be used for tex1Dfetch.
